### PR TITLE
ccadb-csv: 0.4.1, update moz roots report URL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "ccadb-csv"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "csv",
  "serde",

--- a/ccadb-csv/Cargo.toml
+++ b/ccadb-csv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ccadb-csv"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "MPL-2.0"
 description = "Thin wrappers around Common CA Database (CCADB) CSV report content."

--- a/ccadb-csv/src/lib.rs
+++ b/ccadb-csv/src/lib.rs
@@ -292,7 +292,7 @@ pub mod mozilla_included_roots {
 
     /// URL for the CCADB Mozilla included CA certificate PEM CSV report.
     pub const URL: &str =
-        "https://ccadb-public.secure.force.com/mozilla/IncludedCACertificateReportPEMCSV";
+        "https://ccadb.my.salesforce-sites.com/mozilla/IncludedCACertificateReportPEMCSV";
 
     #[allow(dead_code)]
     #[derive(Debug, Clone, Hash, Eq, PartialEq, Deserialize)]


### PR DESCRIPTION
Per Chris Clements' update to [the mailing list](https://groups.google.com/a/ccadb.org/g/public/c/VXfaU1_OaHE/m/58V-lTXVAQAJ):

> We recommend users review their linked bookmarks, automation scripts,
> integration programs, or similar and:
>
> Change their references to public report URLs
>
> from:
>  ccadb-public.secure.force.com (non-enhanced)
>  ccadb-public.force.com (non-enhanced)
> to:
>  ccadb.my.salesforce-sites.com (enhanced)

Resolves https://github.com/cpu/ccadb-utils/issues/124